### PR TITLE
Fix change box handling in tx interpreter

### DIFF
--- a/src/api/ergo/transaction/interpreter/txInterpreter.ts
+++ b/src/api/ergo/transaction/interpreter/txInterpreter.ts
@@ -179,13 +179,13 @@ export class TxInterpreter {
       const nonChangeAssets = o.assets.filter((asset) => {
         return (
           remainingOwnInputAssets[asset.tokenId] === undefined ||
-          remainingOwnInputAssets[asset.tokenId] < toBigNumber(asset.amount)
+          remainingOwnInputAssets[asset.tokenId].isLessThan(asset.amount)
         );
       });
       if (nonChangeAssets.length === 0) {
         o.assets.forEach((asset) => {
           remainingOwnInputAssets[asset.tokenId] = remainingOwnInputAssets[asset.tokenId].minus(
-            toBigNumber(asset.amount)
+            asset.amount
           );
         });
         changeBoxes.push(o);


### PR DESCRIPTION
* In some cases, there is no appropriate change box. This commit fixes the behaviour where a box was considered to be a change box even though it contained non-change assets. This was because the change box was simply determined by taking the last output going to own address. This is especially bad for multiwitness txs with `sign_tx_inputs`, as a non-change input is hidden from the `TxSignView`.

* Participants inputs are aggregated and if an output going to own address exists and it only includes assets from aggregation of own inputs, this output is marked as change box.

* For multiwitness txs, there can be different change boxes for each participant (the wallet always selects the change box in respect to the participant).