### PR TITLE
Fix delta calculation when sending all assets

### DIFF
--- a/src/api/ergo/transaction/interpreter/txInterpreter.ts
+++ b/src/api/ergo/transaction/interpreter/txInterpreter.ts
@@ -114,6 +114,8 @@ export class TxInterpreter {
   private _calcIncomingLeavingTotals() {
     const ownInputAssets = utxoSum(this._ownInputs.map(boxCandidateToBoxAmounts));
     const ownOutputAssets = utxoSum(this._ownOutputs.map(boxCandidateToBoxAmounts));
+    ownInputAssets.nanoErgs = ownInputAssets.nanoErgs ?? 0n;
+    ownOutputAssets.nanoErgs = ownOutputAssets.nanoErgs ?? 0n;
 
     // Set amounts of tokens that are in own inputs, but not on own outputs to 0 in outputs,
     // so utxoSumResultDiff will calculate delta correctly instead of ignoring those tokens


### PR DESCRIPTION
* Not including `nanoErgs` when they were 0 to `utxoSumResultDiff` was causing an exception in case of sending all assets and ergs.